### PR TITLE
Loosen version dependency on faraday

### DIFF
--- a/code42.gemspec
+++ b/code42.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec',   '~> 2.11.0'
   gem.add_development_dependency 'webmock', '~> 1.11.0'
   gem.add_development_dependency 'vcr',     '~> 2.5.0'
-  gem.add_dependency 'faraday',             '~> 0.8.7'
+  gem.add_dependency 'faraday',             '>= 0.8.7'
   gem.add_dependency 'activesupport',       '~> 3.2.0'
   gem.add_dependency 'faraday_middleware',  '~> 0.9.0'
 


### PR DESCRIPTION
Having trouble using the gem in a project that depends on faraday 0.9.0
