### PR TITLE
Changed settings to be an attr_reader so we are no longer re-defining it.

### DIFF
--- a/lib/code42/client.rb
+++ b/lib/code42/client.rb
@@ -10,7 +10,7 @@ module Code42
     include Code42::API::Token
     include Code42::API::PasswordReset
 
-    attr_accessor :settings
+    attr_reader :settings
 
     def initialize(options = {})
       self.settings = options


### PR DESCRIPTION
My Ruby foo may be weak, but we have below this line:

```
def settings=(options)
  @settings = Settings.new(options)
end
```

Which is causing a redundant redefinition.
