### PR TITLE
Errors should contain response object.

### DIFF
--- a/lib/code42/attribute.rb
+++ b/lib/code42/attribute.rb
@@ -4,9 +4,9 @@ module Code42
     alias_method :to, :name
 
     def initialize(name, options = {})
-      @name = name.to_sym
-      @from = (options[:from] || name.to_s.camelize(:lower)).to_s
-      @as   = options[:as]
+      @name       = name.to_sym
+      @from       = (options[:from] || name.to_s.camelize(:lower)).to_s
+      @as         = options[:as]
       @collection = options[:collection]
     end
   end

--- a/lib/code42/connection.rb
+++ b/lib/code42/connection.rb
@@ -108,7 +108,7 @@ module Code42
         when 401
           Code42::Error::AuthenticationError
         when 403
-          Code42::Error::ResourceNotFound
+          Code42::Error::AuthorizationError
         when 404
           Code42::Error::ResourceNotFound
         else

--- a/lib/code42/error.rb
+++ b/lib/code42/error.rb
@@ -1,9 +1,12 @@
 module Code42
   class Error < StandardError;
-    attr_reader :status
-    def initialize(message = nil, status = nil)
+    attr_reader :status, :response
+
+    def initialize(message = nil, status = nil, response = nil)
       super(message)
-      @status = status
+
+      @status   = status
+      @response = response
     end
   end
 

--- a/spec/code42/client_spec.rb
+++ b/spec/code42/client_spec.rb
@@ -92,7 +92,11 @@ describe Code42::Client, :vcr do
     context "when providing invalid credentials" do
       it "should raise an exception" do
         client.settings.password = 'badpassword'
-        expect{client.get_token}.to raise_error Code42::Error::AuthenticationError
+        expect{client.get_token}.to raise_error { |error|
+          expect(error).to be_a Code42::Error::AuthenticationError
+          expect(error.status).to eq 401
+          expect(error.response.body.first['description']).to eq "Invalid or missing credentials"
+        }
       end
     end
   end


### PR DESCRIPTION
Consumers should have access to the response object when an exception is raised.
