### PR TITLE
Replaced 'delegate' with 'instance_delegate' to avoid collisions

### DIFF
--- a/lib/code42/client.rb
+++ b/lib/code42/client.rb
@@ -22,7 +22,7 @@ module Code42
 
     extend Forwardable
 
-    delegate make_request: :connection
+    instance_delegate make_request: :connection
 
     def initialize(options = {})
       self.settings = options

--- a/lib/code42/connection.rb
+++ b/lib/code42/connection.rb
@@ -24,7 +24,7 @@ module Code42
     instance_delegate %i(host  port  path_prefix  scheme)  => :adapter
     instance_delegate %i(host= port= path_prefix= scheme=) => :adapter
 
-    delegate %i(get post put delete) => :adapter
+    instance_delegate %i(get post put delete) => :adapter
 
     def verify_https=(verify_https)
       adapter.ssl[:verify] = verify_https


### PR DESCRIPTION
Replaced 'delegate' with 'instance_delegate' to avoid collisions between ruby's Forwardable 'delegate' method and ActiveRecord's 'delegate' method.
